### PR TITLE
Use filename rather than full path for playlist name

### DIFF
--- a/src/MusicDatabase.h
+++ b/src/MusicDatabase.h
@@ -212,7 +212,7 @@ public:
                     if (l != "") songs.emplace_back(l);
                 }
             }
-            name = f.string();
+            name = f.filename().string();
         }
         std::string name;
         std::string fileName;


### PR DESCRIPTION
Fixes #60 

I'm not 100% sure this is the right fix, but it lets me access the Favorites playlist again. However, the whole file path still comes up in search results rather than just the playlist name